### PR TITLE
fixed level coloring in case of uppercase level labels + default color for DEBUG is gray

### DIFF
--- a/lib/pretty.js
+++ b/lib/pretty.js
@@ -21,7 +21,7 @@ const defaultLevelsColors = {
   info: chalk.bold.greenBright,
   http: chalk.bold.rgb(190, 190, 190),
   verbose: chalk.bold.cyanBright,
-  debug: chalk.bold.blueBright,
+  debug: chalk.bold.gray,
   silly: chalk.bold.magentaBright
 }
 
@@ -149,8 +149,8 @@ function setColorFunc (keys) {
         key === 'level' && (args.hasOwnProperty('level-key') ? args['level-key'] : true))
       ) {
         renderColor = (str) => {
-          if (defaultLevelsColors[str]) {
-            return defaultLevelsColors[str](str)
+          if (defaultLevelsColors[str.toLowerCase()]) {
+            return defaultLevelsColors[str.toLowerCase()](str)
           } else {
             let hexColor = getRandomColor(str)
             return chalk.hex(hexColor).bold(str)


### PR DESCRIPTION
Often levels are in uppercase (INFO, DEBUG, ERROR), this change will use predefined color schemes  from defaultLevelsColors array instead of using getRandomColor.
Also changed default color for DEBUG to gray instead of blueBright (subjective choice, of cause).